### PR TITLE
Remove Status from Facemash Page

### DIFF
--- a/frontend/src/components/candidateBox.js
+++ b/frontend/src/components/candidateBox.js
@@ -12,7 +12,8 @@ import { statusEnum } from '../utils/enums'
 import { setStatus } from '../actions/actionCreators'
 
 type Props = {
-  candidate: {}
+  candidate: {},
+  hideStatus?: boolean
 }
 
 const mapDispatchToProps = dispatch => {
@@ -28,7 +29,7 @@ class CandidateBox extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      status: this.props.candidate.status
+      status: this.props.candidate.status,
     }
   }
   handleChange = e => {
@@ -46,24 +47,28 @@ class CandidateBox extends Component {
         <div>
           <h2>
             {candidate.name}
-            <Badge color={this.state.status == 'rejected' ? 'danger' : 'success'}>
-              {this.state.status}
-            </Badge>
+            {!this.props.hideStatus &&
+              <Badge color={this.state.status == 'rejected' ? 'danger' : 'success'}>
+                {this.state.status}
+              </Badge>
+            }
           </h2>
-          <a>
-            <p>
-              Change Status:
-              <select onChange={this.handleChange}>
-                <option value="" selected disabled hidden>
-                  Choose here
-                </option>
-                <option value={statusEnum.PENDING}>Pending</option>
-                <option value={statusEnum.ACCEPTED}>Accepted</option>
-                <option value={statusEnum.DENIED}>Rejected</option>
-                <option value={statusEnum.INTERVIEWING}>Interviewing</option>
-              </select>
-            </p>
-          </a>
+          {!this.props.hideStatus &&
+            <a>
+              <p>
+                Change Status:
+                <select onChange={this.handleChange}>
+                  <option value="" selected disabled hidden>
+                    Choose here
+                  </option>
+                  <option value={statusEnum.PENDING}>Pending</option>
+                  <option value={statusEnum.ACCEPTED}>Accepted</option>
+                  <option value={statusEnum.DENIED}>Rejected</option>
+                  <option value={statusEnum.INTERVIEWING}>Interviewing</option>
+                </select>
+              </p>
+            </a>
+          }
           <a
             style={{ textDecoration: candidate.resumeID ? null : 'line-through' }}
             href={

--- a/frontend/src/components/candidateBox.js
+++ b/frontend/src/components/candidateBox.js
@@ -29,7 +29,7 @@ class CandidateBox extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      status: this.props.candidate.status,
+      status: this.props.candidate.status
     }
   }
   handleChange = e => {
@@ -47,13 +47,13 @@ class CandidateBox extends Component {
         <div>
           <h2>
             {candidate.name}
-            {!this.props.hideStatus &&
+            {!this.props.hideStatus && (
               <Badge color={this.state.status == 'rejected' ? 'danger' : 'success'}>
                 {this.state.status}
               </Badge>
-            }
+            )}
           </h2>
-          {!this.props.hideStatus &&
+          {!this.props.hideStatus && (
             <a>
               <p>
                 Change Status:
@@ -68,7 +68,7 @@ class CandidateBox extends Component {
                 </select>
               </p>
             </a>
-          }
+          )}
           <a
             style={{ textDecoration: candidate.resumeID ? null : 'line-through' }}
             href={

--- a/frontend/src/pages/facemash.js
+++ b/frontend/src/pages/facemash.js
@@ -98,13 +98,13 @@ class FaceMash extends Component<Props> {
           <p>{this.state.message}</p>
           <div className="row">
             <div className="col-md-6">
-              <Candidate candidate={candidates[0]} hideStatus={true}/>
+              <Candidate candidate={candidates[0]} hideStatus={true} />
               <button name="0" className="btn btn-info" onClick={this.handleClick}>
                 Pick
               </button>
             </div>
             <div className="col-md-6">
-              <Candidate candidate={candidates[1]} hideStatus={true}/>
+              <Candidate candidate={candidates[1]} hideStatus={true} />
               <button name="1" className="btn btn-info" onClick={this.handleClick}>
                 Pick
               </button>

--- a/frontend/src/pages/facemash.js
+++ b/frontend/src/pages/facemash.js
@@ -98,13 +98,13 @@ class FaceMash extends Component<Props> {
           <p>{this.state.message}</p>
           <div className="row">
             <div className="col-md-6">
-              <Candidate candidate={candidates[0]} />
+              <Candidate candidate={candidates[0]} hideStatus={true}/>
               <button name="0" className="btn btn-info" onClick={this.handleClick}>
                 Pick
               </button>
             </div>
             <div className="col-md-6">
-              <Candidate candidate={candidates[1]} />
+              <Candidate candidate={candidates[1]} hideStatus={true}/>
               <button name="1" className="btn btn-info" onClick={this.handleClick}>
                 Pick
               </button>


### PR DESCRIPTION
No Issue
We shouldn't be displaying statuses (Rejected, Accepted, etc.) in Facemash because everyone will be pending when we are using facemash. We also shouldn't be able to change status from here. Any other page using the `candidateBox` component that Facemash uses remains unchanged (see third screenshot).

**Old Look:**
![capture](https://user-images.githubusercontent.com/18370633/43994943-de3fe0a0-9d6a-11e8-8475-b96d3eb85112.PNG)

**New Look:**
![capture1](https://user-images.githubusercontent.com/18370633/43994950-0726a918-9d6b-11e8-82bf-149890b945d4.PNG)

**Unchanged** (from candidate page):
![capture2](https://user-images.githubusercontent.com/18370633/43994952-1a47ebf6-9d6b-11e8-88ae-6d884faa1580.PNG)
