### PR TITLE
schedule upload page completed

### DIFF
--- a/frontend/src/components/nav.js
+++ b/frontend/src/components/nav.js
@@ -102,6 +102,9 @@ class NavigationBar extends Component {
               <Link prefetch href="/interviewportal">
                 <a className="nav-bar-link pl-3">Interview Portal</a>
               </Link>
+              <Link prefetch href="/interviewschedule">
+                <a className="nav-bar-link pl-3">Interview Schedule</a>
+              </Link>
               <Nav navbar>
                 <Link prefetch href="/table">
                   <a className="nav-bar-link pl-3">Table View</a>

--- a/frontend/src/pages/interviewschedule.js
+++ b/frontend/src/pages/interviewschedule.js
@@ -11,25 +11,30 @@ type Props = {}
 
 const mapStateToProps = state => ({})
 
-class InterviewSchedule extends Component<Props>{
-  constructor(props){
+class InterviewSchedule extends Component<Props> {
+  constructor(props) {
     super(props)
-    this.uploadSchedule = this.uploadSchedule.bind(this);
+    this.uploadSchedule = this.uploadSchedule.bind(this)
   }
 
   uploadSchedule(e) {
-    e.preventDefault();
+    e.preventDefault()
 
-    addInterviewSchedule(this.uploadInput.files[0]);
+    addInterviewSchedule(this.uploadInput.files[0])
   }
 
   render() {
-    return(
+    return (
       <Container>
         <form onSubmit={this.uploadSchedule}>
           <div>
             <h2>Select CSV file to upload</h2>
-            <input ref={(ref) => { this.uploadInput = ref; }} type="file"/>
+            <input
+              ref={ref => {
+                this.uploadInput = ref
+              }}
+              type="file"
+            />
           </div>
           <button type="submit">Parse Schedule</button>
         </form>

--- a/frontend/src/pages/interviewschedule.js
+++ b/frontend/src/pages/interviewschedule.js
@@ -1,0 +1,41 @@
+import { Container, Button, Table, Row } from 'reactstrap'
+import { Component } from 'react'
+import Router from 'next/router'
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import VerificationModal from '../components/verificationModal'
+import ActionButton from '../components/actionButton'
+import { addInterviewSchedule } from '../utils/api'
+
+type Props = {}
+
+const mapStateToProps = state => ({})
+
+class InterviewSchedule extends Component<Props>{
+  constructor(props){
+    super(props)
+    this.uploadSchedule = this.uploadSchedule.bind(this);
+  }
+
+  uploadSchedule(e) {
+    e.preventDefault();
+
+    addInterviewSchedule(this.uploadInput.files[0]);
+  }
+
+  render() {
+    return(
+      <Container>
+        <form onSubmit={this.uploadSchedule}>
+          <div>
+            <h2>Select CSV file to upload</h2>
+            <input ref={(ref) => { this.uploadInput = ref; }} type="file"/>
+          </div>
+          <button type="submit">Parse Schedule</button>
+        </form>
+      </Container>
+    )
+  }
+}
+
+export default connect()(InterviewSchedule)

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -10,19 +10,16 @@ const API_URL =
 
 function addInterviewSchedule(file: File) {
   return fetch(`${API_URL}/interviews/scheduleUpload/?key=${getKey()}`, {
-      method: 'POST',
-      headers: {
-        "content-type":"application/CSV"
-      },
-      body: file
-      }).then(
-        res => res.json()
-      ).then(
-        success => console.log(success)
-      ).catch(
-        error => console.log(error)
-      );
-  }
+    method: 'POST',
+    headers: {
+      'content-type': 'application/CSV'
+    },
+    body: file
+  })
+    .then(res => res.json())
+    .then(success => console.log(success))
+    .catch(error => console.log(error))
+}
 
 function getCandidateById(id: string) {
   return fetch(`${API_URL}/candidates/${id}?key=${getKey()}`).then(res => res.json())

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -6,7 +6,23 @@ const getKey = () => sessionStorage.getItem('interviewerKey')
 const API_URL =
   process.env.NODE_ENV === 'production'
     ? 'https://hack4impact-recruitment-backend.now.sh'
-    : 'http://localhost:8080'
+    : 'http://52.14.207.0:8080'
+
+function addInterviewSchedule(file: File) {
+  return fetch(`${API_URL}/interviews/scheduleUpload/?key=${getKey()}`, {
+      method: 'POST',
+      headers: {
+        "content-type":"application/CSV"
+      },
+      body: file
+      }).then(
+        res => res.json()
+      ).then(
+        success => console.log(success)
+      ).catch(
+        error => console.log(error)
+      );
+  }
 
 function getCandidateById(id: string) {
   return fetch(`${API_URL}/candidates/${id}?key=${getKey()}`).then(res => res.json())
@@ -148,6 +164,7 @@ function deleteInterview(candidateId: string, interviewId: string) {
 }
 
 export {
+  addInterviewSchedule,
   getPastInterviews,
   getCandidateInterviews,
   validateKey,


### PR DESCRIPTION
Resolves #215 

This PR adds a new page to the tool: "Interview Schedule"
The page consists of an upload field/button to submit a schedule file.
Once the file is submitted a POST request is sent to the backend to be parsed.

In future additions, this page will also display the interview schedule. In fact, the page I added here will be a subpage of the interview schedule display page.