### PR TITLE
Schedule parser

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,8 @@
     "body-parser": "1.18.2",
     "cheerio": "1.0.0-rc.2",
     "cors": "2.8.4",
+    "csv-array": "0.0.22",
+    "csv-parser": "^2.1.0",
     "express": "4.16.3",
     "helmet": "^3.13.0",
     "mongoose": "5.0.12",

--- a/backend/src/api/futureInterview.js
+++ b/backend/src/api/futureInterview.js
@@ -1,0 +1,128 @@
+const express = require('express')
+var mongodb = require('mongodb')
+const csv = require('csv-array')
+const { errorWrap, leadsOnly } = require('../middleware')
+const { FutureInterview } = require('../models')
+const keyPath =
+  process.env.NODE_ENV === 'test' ? '../../tests/artifacts/test-keys.json' : process.env.KEY_JSON
+const keyData = require(keyPath)
+
+const router = express.Router()
+
+router.post(
+  '/upload',
+  [leadsOnly],
+  errorWrap(async (req, res) => {
+    const data = req.body['schedule']
+    console.log(data)
+    let response = 'Schedule Adding Failed'
+    let code = 404
+
+    //TODO: parse schedule
+    var arr = data.split('\n').map(function(e) {
+      return e.split(',')
+    })
+    var date = arr[0][0]
+    var headers = arr[0]
+
+    for (var i = 1; i < arr.length; i++) {
+      for (var j = 1; j < arr[i].length; j++) {
+        if (arr[i][j] === '') continue
+
+        var interview = arr[i][j]
+        var interviewers = interview
+          .split(':')[1]
+          .split(';')[0]
+          .split('&')
+          .map(s => s.trim())
+        var interviewees = interview
+          .split(':')[2]
+          .split('&')
+          .map(s => s.trim())
+
+        let newInterview = new FutureInterview({
+          candidates: interviewees,
+          interviewers: interviewers,
+          room: arr[0][j],
+          date: date,
+          time: arr[i][0]
+        })
+        const res = await newInterview.save()
+        console.log(res)
+      }
+    }
+
+    response = 'Schedule Added Sucessfully'
+    code = 200
+    res.json({
+      code,
+      message: response,
+      result: data,
+      success: true
+    })
+  })
+)
+
+router.post(
+  '/populateTest',
+  errorWrap(async (req, res) => {
+    var newInterview = new FutureInterview({
+      candidates: ['Steve Jobs'],
+      interviewers: ['Tim Ko'],
+      room: 'Room A',
+      date: '01/24/2019',
+      time: '10:00AM'
+    })
+    await newInterview.save()
+
+    newInterview = new FutureInterview({
+      candidates: ['Bill Gates'],
+      interviewers: ['Tim Ko'],
+      room: 'Room B',
+      date: '01/25/2019',
+      time: '2:00PM'
+    })
+
+    await newInterview.save()
+
+    res.json({
+      code: 200,
+      message: 'Populated.',
+      result: {},
+      success: true
+    })
+  })
+)
+
+router.get(
+  '/',
+  [leadsOnly],
+  errorWrap(async (req, res) => {
+    const futureInterviews = await FutureInterview.find()
+    let interviews = []
+    let code = 500
+    //TODO: do stuff
+    //retrieve list of FutureInterviews and return them
+
+    /*
+    for (var idx = 0; idx < futureInterviews.length; idx++) {
+      if (futureInterviews[idx].date > //!!current date - how do this?!!//) {
+        interviews.push(futureInterviews[idx])
+      }
+    }
+    */
+
+    //for now we'll do:
+    interviews = futureInterviews
+    code = 200
+    res.json({
+      code,
+      message: 'This endpoint must be implemented',
+      result: { interviews },
+      success: true
+    })
+  })
+)
+
+//END
+module.exports = router

--- a/backend/src/api/index.js
+++ b/backend/src/api/index.js
@@ -1,11 +1,13 @@
 const candidates = require('./candidates')
 const interview = require('./interview')
+const futureInterview = require('./futureInterview')
 const matchCandidates = require('./matchCandidates')
 const matches = require('./matches')
 
 module.exports = {
   candidates,
   interview,
+  futureInterview,
   matchCandidates,
   matches
 }

--- a/backend/src/models/futureInterview.js
+++ b/backend/src/models/futureInterview.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose')
+/*
+* This model is used by the schedule parser to describe a planned interview.
+* In the future we can consider adding an 'added_by' field to denote who
+* uploaded the schedule that contains this interview plan. We can also consider
+* adding a FutureInterview schema to a candidate. For now it is just a model.
+*/
+const FutureInterview = new mongoose.Schema({
+  candidates: [{ type: String }],
+  interviewers: [{ type: String }],
+  room: { type: String },
+  date: { type: String },
+  time: { type: String }
+})
+
+module.exports = mongoose.model('FutureInterview', FutureInterview)

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -1,6 +1,7 @@
 // This module defines the mongoose models used for Mongo
 const Candidate = require('./candidate')
 const Interview = require('./interview').InterviewModel
+const FutureInterview = require('./futureInterview')
 const Stats = require('./stats')
 const Match = require('./match')
 const Comment = require('./comment').CommentModel
@@ -10,5 +11,6 @@ module.exports = {
   Stats,
   Match,
   Interview,
+  FutureInterview,
   Comment
 }

--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const router = express.Router()
-const { interview, candidates, matchCandidates, matches } = require('./api')
+const { interview, futureInterview, candidates, matchCandidates, matches } = require('./api')
 var XLSX = require('xlsx')
 
 // mydomain.com/
@@ -10,6 +10,7 @@ router.get('/', (req, res) => {
 
 // sets up the routers defined in the module /src/api
 router.use('/interviews', interview)
+router.use('/schedule', futureInterview)
 router.use('/candidates', candidates)
 router.use('/matchCandidates', matchCandidates)
 router.use('/matches', matches)

--- a/frontend/src/components/nav.js
+++ b/frontend/src/components/nav.js
@@ -102,6 +102,9 @@ class NavigationBar extends Component {
               <Link prefetch href="/interviewportal">
                 <a className="nav-bar-link pl-3">Interview Portal</a>
               </Link>
+              <Link prefetch href="/interviewschedule">
+                <a className="nav-bar-link pl-3">Interview Schedule</a>
+              </Link>
               <Nav navbar>
                 <Link prefetch href="/table">
                   <a className="nav-bar-link pl-3">Table View</a>

--- a/frontend/src/pages/interviewschedule.js
+++ b/frontend/src/pages/interviewschedule.js
@@ -1,0 +1,46 @@
+import { Container, Button, Table, Row } from 'reactstrap'
+import { Component } from 'react'
+import Router from 'next/router'
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import VerificationModal from '../components/verificationModal'
+import ActionButton from '../components/actionButton'
+import { addInterviewSchedule } from '../utils/api'
+
+type Props = {}
+
+const mapStateToProps = state => ({})
+
+class InterviewSchedule extends Component<Props> {
+  constructor(props) {
+    super(props)
+    this.uploadSchedule = this.uploadSchedule.bind(this)
+  }
+
+  uploadSchedule(e) {
+    e.preventDefault()
+
+    addInterviewSchedule(this.uploadInput.files[0])
+  }
+
+  render() {
+    return (
+      <Container>
+        <form onSubmit={this.uploadSchedule}>
+          <div>
+            <h2>Select CSV file to upload</h2>
+            <input
+              ref={ref => {
+                this.uploadInput = ref
+              }}
+              type="file"
+            />
+          </div>
+          <button type="submit">Parse Schedule</button>
+        </form>
+      </Container>
+    )
+  }
+}
+
+export default connect()(InterviewSchedule)

--- a/frontend/src/pages/interviewschedule.js
+++ b/frontend/src/pages/interviewschedule.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import VerificationModal from '../components/verificationModal'
 import ActionButton from '../components/actionButton'
-import { addInterviewSchedule } from '../utils/api'
+import { getInterviewSchedule, addInterviewSchedule } from '../utils/api'
 
 type Props = {}
 
@@ -15,6 +15,11 @@ class InterviewSchedule extends Component<Props> {
   constructor(props) {
     super(props)
     this.uploadSchedule = this.uploadSchedule.bind(this)
+
+    this.state = {
+      interviews: this.props.interviews,
+      interviewCards: this.props.interviewCards
+    }
   }
 
   uploadSchedule(e) {
@@ -23,22 +28,103 @@ class InterviewSchedule extends Component<Props> {
     addInterviewSchedule(this.uploadInput.files[0])
   }
 
+  getInterviewCard = interview => {
+    if (interview === undefined) {
+      return null
+    }
+    //return populated interview card
+    return (
+      <div className="interview-card future-interview">
+        <a>Time: {interview.time}</a>
+        <br />
+        <a>Room: {interview.room}</a>
+        <br />
+        <a>Interviewers: {interview.interviewers.join(', ')}</a>
+        <br />
+        <a>Candidates: {interview.candidates.join(', ')}</a>
+        <br />
+      </div>
+    )
+  }
+
+  getAllInterviewCards = interviews => {
+    var days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+    var d = new Date()
+
+    var jsx = []
+
+    //sort interviews by date
+    interviews = interviews.sort((a, b) => {
+      var adatetime = a.date + ' ' + a.time
+      var bdatetime = b.date + ' ' + b.time
+      return this.compareDates(adatetime, bdatetime)
+    })
+
+    var cd = new Date() //current date we're operating on, for day grouping
+    cd.setHours(0, 0, 0, 0)
+    cd.setFullYear(0, 0, 0)
+    interviews.forEach(i => {
+      if (d > new Date(i.date + ' ' + i.time)) {
+        return
+      }
+      if (cd.getDate() !== new Date(i.date).getDate()) {
+        cd = new Date(i.date)
+        cd.setHours(0, 0, 0, 0)
+        jsx.push(<br />)
+        jsx.push(<h4 style={{ clear: 'both' }}>{days[cd.getDay()] + ', ' + i.date}</h4>)
+      }
+      jsx.push(this.getInterviewCard(i))
+    })
+    return jsx
+  }
+
+  compareDates = (a, b) => {
+    //Given two datetime strings, compare them
+    var adate = new Date(a)
+    var bdate = new Date(b)
+    if (adate < bdate) {
+      return -1
+    } else if (adate > bdate) {
+      return 1
+    } else {
+      return 0
+    }
+  }
+
+  async componentDidMount() {
+    const res = await getInterviewSchedule()
+    var interviewList = res.result.interviews
+    console.log(interviewList)
+    this.setState({
+      interviews: interviewList === undefined ? [] : interviewList,
+      interviewCards: interviewList === undefined ? [] : this.getAllInterviewCards(interviewList)
+    })
+  }
+
   render() {
     return (
-      <Container>
-        <form onSubmit={this.uploadSchedule}>
-          <div>
-            <h2>Select CSV file to upload</h2>
-            <input
-              ref={ref => {
-                this.uploadInput = ref
-              }}
-              type="file"
-            />
-          </div>
-          <button type="submit">Parse Schedule</button>
-        </form>
-      </Container>
+      <div>
+        <Container style={{ overflow: 'hidden' }}>
+          <h1>Upcoming Interviews</h1>
+          {this.state.interviewCards}
+        </Container>
+        <hr />
+        <Container>
+          <form onSubmit={this.uploadSchedule}>
+            <div>
+              <h2>Upload a New Schedule</h2>
+              <input
+                ref={ref => {
+                  this.uploadInput = ref
+                }}
+                type="file"
+              />
+            </div>
+            <button type="submit">Parse Schedule</button>
+          </form>
+          <br />
+        </Container>
+      </div>
     )
   }
 }

--- a/frontend/src/pages/interviewschedule.js
+++ b/frontend/src/pages/interviewschedule.js
@@ -35,14 +35,18 @@ class InterviewSchedule extends Component<Props> {
     //return populated interview card
     return (
       <div className="interview-card future-interview">
-        <a>Time: {interview.time}</a>
-        <br />
-        <a>Room: {interview.room}</a>
-        <br />
-        <a>Interviewers: {interview.interviewers.join(', ')}</a>
-        <br />
-        <a>Candidates: {interview.candidates.join(', ')}</a>
-        <br />
+        <p>
+          <b>Time:</b> {interview.time}
+        </p>
+        <p>
+          <b>Room:</b> {interview.room}
+        </p>
+        <p>
+          <b>Interviewers:</b> {interview.interviewers.join(', ')}
+        </p>
+        <p>
+          <b>Candidates:</b> {interview.candidates.join(', ')}
+        </p>
       </div>
     )
   }
@@ -71,7 +75,11 @@ class InterviewSchedule extends Component<Props> {
         cd = new Date(i.date)
         cd.setHours(0, 0, 0, 0)
         jsx.push(<br />)
-        jsx.push(<h4 style={{ clear: 'both' }}>{days[cd.getDay()] + ', ' + i.date}</h4>)
+        jsx.push(
+          <h4 className="pt-5" style={{ clear: 'both' }}>
+            {days[cd.getDay()] + ', ' + i.date}
+          </h4>
+        )
       }
       jsx.push(this.getInterviewCard(i))
     })

--- a/frontend/src/static/style.css
+++ b/frontend/src/static/style.css
@@ -181,6 +181,20 @@ p > b {
   box-shadow: 0 0 4px 1px rgba(0, 0, 0, 0.01), 0 3px 24px rgba(48, 51, 51, 0.09);
 }
 
+.future-interview {
+  float: left;
+  width: 18%;
+  min-width: max-content;
+  background-color: #77dd77;
+  margin-left: 5px;
+  margin-right: 5px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  border: medium solid #000000;
+  border-radius: 4px;
+  text-align: center;
+}
+
 .nav-bar-name {
   font-size: 10pt;
   color: #ffffff !important;

--- a/frontend/src/static/style.css
+++ b/frontend/src/static/style.css
@@ -190,9 +190,19 @@ p > b {
   margin-right: 5px;
   margin-top: 5px;
   margin-bottom: 5px;
-  border: medium solid #000000;
+  padding: 20px 20px;
+  /* border: medium solid #000000; */
   border-radius: 4px;
-  text-align: center;
+  text-align: left;
+}
+
+.interview-card p{
+  margin-bottom: 5px;
+  font-size: 13px;
+}
+.interview-card:hover {
+  box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+    0px 3px 1px -2px rgba(0, 0, 0, 0.12);
 }
 
 .nav-bar-name {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -28,6 +28,10 @@ function addInterviewSchedule(file: File) {
   reader.readAsText(file)
 }
 
+function getInterviewSchedule() {
+  return fetch(`${API_URL}/schedule?key=${getKey()}`).then(res => res.json())
+}
+
 function getCandidateById(id: string) {
   return fetch(`${API_URL}/candidates/${id}?key=${getKey()}`).then(res => res.json())
 }
@@ -169,6 +173,7 @@ function deleteInterview(candidateId: string, interviewId: string) {
 
 export {
   addInterviewSchedule,
+  getInterviewSchedule,
   getPastInterviews,
   getCandidateInterviews,
   validateKey,

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -6,7 +6,20 @@ const getKey = () => sessionStorage.getItem('interviewerKey')
 const API_URL =
   process.env.NODE_ENV === 'production'
     ? 'https://hack4impact-recruitment-backend.now.sh'
-    : 'http://localhost:8080'
+    : 'http://52.14.207.0:8080'
+
+function addInterviewSchedule(file: File) {
+  return fetch(`${API_URL}/interviews/scheduleUpload/?key=${getKey()}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/CSV'
+    },
+    body: file
+  })
+    .then(res => res.json())
+    .then(success => console.log(success))
+    .catch(error => console.log(error))
+}
 
 function getCandidateById(id: string) {
   return fetch(`${API_URL}/candidates/${id}?key=${getKey()}`).then(res => res.json())
@@ -148,6 +161,7 @@ function deleteInterview(candidateId: string, interviewId: string) {
 }
 
 export {
+  addInterviewSchedule,
   getPastInterviews,
   getCandidateInterviews,
   validateKey,

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -9,16 +9,23 @@ const API_URL =
     : 'http://52.14.207.0:8080'
 
 function addInterviewSchedule(file: File) {
-  return fetch(`${API_URL}/interviews/scheduleUpload/?key=${getKey()}`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/CSV'
-    },
-    body: file
-  })
-    .then(res => res.json())
-    .then(success => console.log(success))
-    .catch(error => console.log(error))
+  var reader = new FileReader()
+  var scheduleString = ''
+  reader.onload = function(e) {
+    scheduleString = reader.result
+    fetch(`${API_URL}/schedule/upload/?key=${getKey()}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ schedule: scheduleString })
+    })
+      .then(res => res.json())
+      .then(success => console.log(success))
+      .catch(error => console.log(error))
+  }
+
+  reader.readAsText(file)
 }
 
 function getCandidateById(id: string) {


### PR DESCRIPTION
Resolves #202 and addresses #171 to some extent. 

This feature allows leads to upload interview schedules (of a predefined format) on the frontend and have the schedule be consumed by the backend and stored as individual interviews. The parsed interviews can then be viewed on the same tab in the frontend.