### PR TITLE
Added Reminder in interview notes + added support for customized page titles

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "react-minimal-pie-chart": "^3.3.0",
     "react-redux": "^5.0.7",
     "react-select": "^2.0.0",
-    "reactstrap": "^6.1.0",
+    "reactstrap": "^8.0.0",
     "redux": "^4.0.0",
     "redux-thunk": "^2.2.0",
     "sort-json-array": "^0.1.7"

--- a/frontend/src/components/candidates/candidateInterviewsModal.js
+++ b/frontend/src/components/candidates/candidateInterviewsModal.js
@@ -67,7 +67,7 @@ class CandidateInterviewsModal extends React.Component<Props> {
                 onExitDetails={this.handleExitDetails}
                 interview={this.state.currentInterview}
               />
-            ) : this.state.interviews ? (
+            ) : this.state.interviews && this.state.interviews.length > 0 ? (
               this.state.interviews.map(interview => {
                 return (
                   <InterviewCard
@@ -81,7 +81,7 @@ class CandidateInterviewsModal extends React.Component<Props> {
                 )
               })
             ) : (
-              <h1> No Interviews Have Been Recorded So Far </h1>
+              <p> No interviews for {this.props.candidateName} have been recorded so far </p>
             )}
           </ModalBody>
           <ModalFooter>

--- a/frontend/src/components/head.js
+++ b/frontend/src/components/head.js
@@ -32,10 +32,11 @@ const Head = props => (
     />
     <link
       rel="stylesheet"
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
-      integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
-      crossOrigin="anonymous"
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+      crossorigin="anonymous"
     />
+
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" />
     <style jsx global>{`
       body {

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -34,7 +34,6 @@ export default withRedux(configureStore, { debug: true })(
         <Container>
           <Provider store={store}>
             <div>
-              <Head />
               {this.state.hasError ? (
                 <ErrorMessage
                   code="404"

--- a/frontend/src/pages/analytics.js
+++ b/frontend/src/pages/analytics.js
@@ -8,6 +8,7 @@ import { Pie } from 'react-chartjs-2'
 import { addFilter, removeFilter } from '../actions'
 import PieComponent from '../components/pieComponent'
 import Nav from '../components/nav'
+import Head from '../components/head'
 
 type Props = {}
 
@@ -118,6 +119,7 @@ class Analytics extends React.Component<Props> {
     }
     return (
       <>
+        <Head title="Analytics" />
         <Nav />
         <div className="page-content-wrapper">
           <Container fluid>

--- a/frontend/src/pages/candidate.js
+++ b/frontend/src/pages/candidate.js
@@ -1,7 +1,8 @@
 import { connect } from 'react-redux'
 import React, { Component } from 'react'
-import { Container, Button, Alert, Row, Col } from 'reactstrap'
+import { Container, Button, Row, Col } from 'reactstrap'
 import Router from 'next/router'
+import Head from '../components/head'
 import { bindActionCreators } from 'redux'
 import Candidate from '../components/candidates/candidateBox'
 import CandidateInterviewsModal from '../components/candidates/candidateInterviewsModal'
@@ -118,6 +119,7 @@ class CandidatePage extends Component<Props> {
     const { candidate } = this.state
     return (
       <>
+        <Head title={candidate.name} />
         <Nav />
         <Container className="mt-5">
           <Row>

--- a/frontend/src/pages/dashboard.js
+++ b/frontend/src/pages/dashboard.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { Container, Row, Table, Col, FormGroup, Label, Input } from 'reactstrap'
 import Link from 'next/link'
 import { connect } from 'react-redux'
+import Head from '../components/head'
 import { bindActionCreators } from 'redux'
 import { addFilter, removeFilter } from '../actions'
 import { getCandidates, setCandidateStatus } from '../utils/api'
@@ -35,19 +36,19 @@ const mapStateToProps = state => ({
   sort: state.candidateListPage.sort
 })
 
-var sortByProperty = function(property) {
-  return function(x, y) {
+var sortByProperty = function (property) {
+  return function (x, y) {
     return x[property] === y[property] ? 0 : x[property] > y[property] ? 1 : -1
   }
 }
 
-var sortByMultipleProperties = function(property1, property2) {
-  return function(x, y) {
+var sortByMultipleProperties = function (property1, property2) {
+  return function (x, y) {
     return x[property1][property2] === y[property1][property2]
       ? 0
       : x[property1][property2] > y[property1][property2]
-      ? 1
-      : -1
+        ? 1
+        : -1
   }
 }
 
@@ -132,6 +133,7 @@ class Dashboard extends React.Component<Props> {
     let selects = this.state.filters.selectBy
     return (
       <>
+        <Head title="Home" />
         <Nav />
         <div className="page-content-wrapper">
           <Container fluid>
@@ -164,8 +166,8 @@ class Dashboard extends React.Component<Props> {
                           {selects.includes(selectByEnum.EMAIL) ? (
                             <th>{selectByEnum.EMAIL}</th>
                           ) : (
-                            <></>
-                          )}
+                              <></>
+                            )}
                           {selects.includes('Status') ? <th>Status</th> : <> </>}
                           {selects.includes('Year') ? <th>Year</th> : <> </>}
                           {selects.includes('Graduation Year') ? <th>Graduation Date</th> : <> </>}
@@ -176,19 +178,19 @@ class Dashboard extends React.Component<Props> {
                           {selects.includes('Strong Referrals') ? (
                             <th>Strong Referrals</th>
                           ) : (
-                            <> </>
-                          )}
+                              <> </>
+                            )}
                           {selects.includes('Referrals') ? <th>Referrals</th> : <> </>}
                           {selects.includes('Avg Interview Score') ? (
                             <th>Avg Interview Score</th>
                           ) : (
-                            <></>
-                          )}
+                              <></>
+                            )}
                           {selects.includes('Number of Interviews') ? (
                             <th>Number of Interviews</th>
                           ) : (
-                            <></>
-                          )}
+                              <></>
+                            )}
                           {selects.includes('Facemash Score') ? <th>FaceMash Score</th> : <> </>}
                           {selects.includes('Number of Matches') ? <th>Matches</th> : <> </>}
                           <th>Change Status</th>
@@ -209,15 +211,15 @@ class Dashboard extends React.Component<Props> {
                                   </Link>
                                 </td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
                               {selects.includes(selectByEnum.EMAIL) ? (
                                 <td>
                                   <span>{candidate.email}</span>
                                 </td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
                               {selects.includes('Status') ? (
                                 <td>
                                   <h6>
@@ -225,26 +227,26 @@ class Dashboard extends React.Component<Props> {
                                   </h6>
                                 </td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
 
                               {selects.includes('Year') ? <td>{candidate.year}</td> : <> </>}
                               {selects.includes('Graduation Year') ? (
                                 <td>{candidate.graduationDate}</td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
                               {selects.includes('Roles') ? (
-                                <td>{candidate.role.join(' ')}</td>
+                                <td>{candidate.role.join(', ')}</td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
                               {selects.includes('Major') ? <td>{candidate.major}</td> : <> </>}
                               {selects.includes('Hours') ? (
                                 <td>{candidate.timeCommitment}</td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
 
                               {selects.includes('Links') ? (
                                 <td>
@@ -254,32 +256,32 @@ class Dashboard extends React.Component<Props> {
                                   <CandidateLinksBadge link={candidate.website} text="Website" />
                                 </td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
 
                               {selects.includes('Strong Referrals') ? (
                                 <td>{candidate.strongReferrals.length}</td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
 
                               {selects.includes('Referrals') ? (
                                 <td>{candidate.referrals.length}</td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
 
                               {selects.includes('Avg Interview Score') ? (
                                 <td> {avgInterviewScore(candidate.interviews)}</td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
 
                               {selects.includes(selectByEnum.NUM_INTERVIEWS) ? (
                                 <td> {getNumOfInterviews(candidate.interviews)}</td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
 
                               {selects.includes('Facemash Score') ? (
                                 <td>
@@ -288,8 +290,8 @@ class Dashboard extends React.Component<Props> {
                                     : null}
                                 </td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
 
                               {selects.includes('Number of Matches') ? (
                                 <td>
@@ -298,8 +300,8 @@ class Dashboard extends React.Component<Props> {
                                     : null}
                                 </td>
                               ) : (
-                                <> </>
-                              )}
+                                  <> </>
+                                )}
 
                               <td>
                                 <ChangeStatus
@@ -319,10 +321,10 @@ class Dashboard extends React.Component<Props> {
                             </tr>
                           ))
                         ) : (
-                          <div className="center">
-                            <p>No Candidates exist given the filters.</p>
-                          </div>
-                        )}
+                            <div className="center">
+                              <p>No Candidates exist given the filters.</p>
+                            </div>
+                          )}
                       </tbody>
                     </Table>
                   </Row>

--- a/frontend/src/pages/dashboard.js
+++ b/frontend/src/pages/dashboard.js
@@ -36,19 +36,19 @@ const mapStateToProps = state => ({
   sort: state.candidateListPage.sort
 })
 
-var sortByProperty = function (property) {
-  return function (x, y) {
+var sortByProperty = function(property) {
+  return function(x, y) {
     return x[property] === y[property] ? 0 : x[property] > y[property] ? 1 : -1
   }
 }
 
-var sortByMultipleProperties = function (property1, property2) {
-  return function (x, y) {
+var sortByMultipleProperties = function(property1, property2) {
+  return function(x, y) {
     return x[property1][property2] === y[property1][property2]
       ? 0
       : x[property1][property2] > y[property1][property2]
-        ? 1
-        : -1
+      ? 1
+      : -1
   }
 }
 
@@ -166,8 +166,8 @@ class Dashboard extends React.Component<Props> {
                           {selects.includes(selectByEnum.EMAIL) ? (
                             <th>{selectByEnum.EMAIL}</th>
                           ) : (
-                              <></>
-                            )}
+                            <></>
+                          )}
                           {selects.includes('Status') ? <th>Status</th> : <> </>}
                           {selects.includes('Year') ? <th>Year</th> : <> </>}
                           {selects.includes('Graduation Year') ? <th>Graduation Date</th> : <> </>}
@@ -178,19 +178,19 @@ class Dashboard extends React.Component<Props> {
                           {selects.includes('Strong Referrals') ? (
                             <th>Strong Referrals</th>
                           ) : (
-                              <> </>
-                            )}
+                            <> </>
+                          )}
                           {selects.includes('Referrals') ? <th>Referrals</th> : <> </>}
                           {selects.includes('Avg Interview Score') ? (
                             <th>Avg Interview Score</th>
                           ) : (
-                              <></>
-                            )}
+                            <></>
+                          )}
                           {selects.includes('Number of Interviews') ? (
                             <th>Number of Interviews</th>
                           ) : (
-                              <></>
-                            )}
+                            <></>
+                          )}
                           {selects.includes('Facemash Score') ? <th>FaceMash Score</th> : <> </>}
                           {selects.includes('Number of Matches') ? <th>Matches</th> : <> </>}
                           <th>Change Status</th>
@@ -211,15 +211,15 @@ class Dashboard extends React.Component<Props> {
                                   </Link>
                                 </td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
                               {selects.includes(selectByEnum.EMAIL) ? (
                                 <td>
                                   <span>{candidate.email}</span>
                                 </td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
                               {selects.includes('Status') ? (
                                 <td>
                                   <h6>
@@ -227,26 +227,26 @@ class Dashboard extends React.Component<Props> {
                                   </h6>
                                 </td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
 
                               {selects.includes('Year') ? <td>{candidate.year}</td> : <> </>}
                               {selects.includes('Graduation Year') ? (
                                 <td>{candidate.graduationDate}</td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
                               {selects.includes('Roles') ? (
                                 <td>{candidate.role.join(', ')}</td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
                               {selects.includes('Major') ? <td>{candidate.major}</td> : <> </>}
                               {selects.includes('Hours') ? (
                                 <td>{candidate.timeCommitment}</td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
 
                               {selects.includes('Links') ? (
                                 <td>
@@ -256,32 +256,32 @@ class Dashboard extends React.Component<Props> {
                                   <CandidateLinksBadge link={candidate.website} text="Website" />
                                 </td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
 
                               {selects.includes('Strong Referrals') ? (
                                 <td>{candidate.strongReferrals.length}</td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
 
                               {selects.includes('Referrals') ? (
                                 <td>{candidate.referrals.length}</td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
 
                               {selects.includes('Avg Interview Score') ? (
                                 <td> {avgInterviewScore(candidate.interviews)}</td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
 
                               {selects.includes(selectByEnum.NUM_INTERVIEWS) ? (
                                 <td> {getNumOfInterviews(candidate.interviews)}</td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
 
                               {selects.includes('Facemash Score') ? (
                                 <td>
@@ -290,8 +290,8 @@ class Dashboard extends React.Component<Props> {
                                     : null}
                                 </td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
 
                               {selects.includes('Number of Matches') ? (
                                 <td>
@@ -300,8 +300,8 @@ class Dashboard extends React.Component<Props> {
                                     : null}
                                 </td>
                               ) : (
-                                  <> </>
-                                )}
+                                <> </>
+                              )}
 
                               <td>
                                 <ChangeStatus
@@ -321,10 +321,10 @@ class Dashboard extends React.Component<Props> {
                             </tr>
                           ))
                         ) : (
-                            <div className="center">
-                              <p>No Candidates exist given the filters.</p>
-                            </div>
-                          )}
+                          <div className="center">
+                            <p>No Candidates exist given the filters.</p>
+                          </div>
+                        )}
                       </tbody>
                     </Table>
                   </Row>

--- a/frontend/src/pages/eventOverview.js
+++ b/frontend/src/pages/eventOverview.js
@@ -19,6 +19,7 @@ import {
 import ActionButton from '../components/actionButton'
 import Nav from '../components/nav'
 import { getAllEvents, createEvent } from '../utils/api'
+import Head from '../components/head'
 
 class EventOverview extends React.Component<Props> {
   constructor(props) {
@@ -88,6 +89,7 @@ class EventOverview extends React.Component<Props> {
     const alert = this.state.alert ? <Alert color="danger">{this.state.alert}</Alert> : null
     return (
       <>
+        <Head title="Events" />
         <Nav />
         <div className="page-content-wrapper">
           <Container fluid>

--- a/frontend/src/pages/facemash.js
+++ b/frontend/src/pages/facemash.js
@@ -9,6 +9,7 @@ import { getCandidateMatch, setMatchWinner } from '../utils/api'
 import Candidate from '../components/facemashProfile'
 import ErrorMessage from '../components/errorMessage'
 import Nav from '../components/nav'
+import Head from '../components/head'
 
 type Props = {
   candidates: Array<any>,
@@ -118,6 +119,7 @@ class FaceMash extends Component<Props> {
 
     return candidates && candidates.length == 2 ? (
       <div>
+        <Head title="Facemash" />
         <Nav />
         <Container>
           <div className="mt-5" style={{ color: '#7f8e9e' }}>
@@ -157,13 +159,13 @@ class FaceMash extends Component<Props> {
               </Col>
             </Row>
           ) : (
-            <ReactLoading className="loader-box" type="spinningBubbles" color="#000" />
-          )}
+              <ReactLoading className="loader-box" type="spinningBubbles" color="#000" />
+            )}
         </Container>
       </div>
     ) : (
-      <ErrorMessage>Error: Couldn&#39;t get new FaceMash match. Please refresh page.</ErrorMessage>
-    )
+        <ErrorMessage>Error: Couldn&#39;t get new FaceMash match. Please refresh page.</ErrorMessage>
+      )
   }
 }
 

--- a/frontend/src/pages/facemash.js
+++ b/frontend/src/pages/facemash.js
@@ -159,13 +159,13 @@ class FaceMash extends Component<Props> {
               </Col>
             </Row>
           ) : (
-              <ReactLoading className="loader-box" type="spinningBubbles" color="#000" />
-            )}
+            <ReactLoading className="loader-box" type="spinningBubbles" color="#000" />
+          )}
         </Container>
       </div>
     ) : (
-        <ErrorMessage>Error: Couldn&#39;t get new FaceMash match. Please refresh page.</ErrorMessage>
-      )
+      <ErrorMessage>Error: Couldn&#39;t get new FaceMash match. Please refresh page.</ErrorMessage>
+    )
   }
 }
 

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -4,7 +4,7 @@ import { Button, Container, Input, Row, Col } from 'reactstrap'
 import { validateKey } from '../utils/api'
 import ReactLoading from 'react-loading'
 import Nav from '../components/nav'
-
+import Head from '../components/head'
 type Props = {}
 
 class LoginPage extends React.Component<Props> {
@@ -46,6 +46,7 @@ class LoginPage extends React.Component<Props> {
   render() {
     return (
       <>
+        <Head />
         <Nav />
         <Container>
           {this.state.loading ? (

--- a/frontend/src/pages/interview.js
+++ b/frontend/src/pages/interview.js
@@ -8,7 +8,10 @@ import {
   Container,
   Col,
   Row,
-  FormFeedback
+  FormFeedback,
+  Toast,
+  ToastHeader,
+  ToastBody
 } from 'reactstrap'
 import Link from 'next/link'
 import React from 'react'
@@ -24,6 +27,7 @@ import InterviewSectionModular from '../components/interviewSectionModular'
 import { getKey, addInterview, getCandidates } from '../utils/api'
 import roundData from '../data/roundData'
 import Nav from '../components/nav'
+import Head from '../components/head'
 
 type Props = {
   error: boolean,
@@ -173,6 +177,7 @@ class Interview extends Component<Props> {
     }
     return (
       <>
+        <Head title={`Adding ${this.props.candidateName} Interview`} />
         <Nav />
         <Container>
           <Row style={{ marginTop: '20px' }}>
@@ -182,6 +187,14 @@ class Interview extends Component<Props> {
             </Col>
             <Col md="4">
               <CandidateDropdown candidates={candidates} />
+            </Col>
+            <Col md="4">
+              <Toast>
+                <ToastHeader icon="warning">
+                  Write your notes somewhere else & copy it over afterwards!
+                </ToastHeader>
+                <ToastBody>Just in case, so you won't lose any of your notes.</ToastBody>
+              </Toast>
             </Col>
           </Row>
           <Row>

--- a/frontend/src/pages/interviewlist.js
+++ b/frontend/src/pages/interviewlist.js
@@ -12,6 +12,7 @@ import { avgInterviewScore, interviewGetCategorySection } from '../utils/core'
 import ActionLink from '../components/actionLink'
 import ActionButton from '../components/actionButton'
 import Nav from '../components/nav'
+import Head from '../components/head'
 import roundData from '../data/roundData'
 
 const CardCol = ({ children, ...rest }) => (
@@ -73,6 +74,7 @@ class InterviewListPage extends React.Component<Props> {
     )
     return (
       <>
+        <Head title="My Interviews" />
         <Nav />
         <Container>
           <Row>

--- a/frontend/src/pages/interviewportal.js
+++ b/frontend/src/pages/interviewportal.js
@@ -154,8 +154,8 @@ class InterviewPortal extends Component<Props> {
                   ]
                 })
               ) : (
-                  <tr>No Interviews</tr>
-                )}
+                <tr>No Interviews</tr>
+              )}
             </tbody>
           </Table>
         </Container>

--- a/frontend/src/pages/interviewportal.js
+++ b/frontend/src/pages/interviewportal.js
@@ -14,6 +14,7 @@ import {
 import VerificationModal from '../components/verificationModal'
 import ActionButton from '../components/actionButton'
 import Nav from '../components/nav'
+import Head from '../components/head'
 
 type Props = {}
 
@@ -91,6 +92,7 @@ class InterviewPortal extends Component<Props> {
     const { interviews } = this.state
     return (
       <>
+        <Head title="Interviews" />
         <Nav />
         <Container>
           <h1>Interviews</h1>
@@ -152,8 +154,8 @@ class InterviewPortal extends Component<Props> {
                   ]
                 })
               ) : (
-                <tr>No Interviews</tr>
-              )}
+                  <tr>No Interviews</tr>
+                )}
             </tbody>
           </Table>
         </Container>

--- a/frontend/src/pages/interviewschedule.js
+++ b/frontend/src/pages/interviewschedule.js
@@ -8,6 +8,7 @@ import ActionButton from '../components/actionButton'
 import Link from 'next/link'
 import { getInterviewSchedule, addInterviewSchedule } from '../utils/api'
 import Nav from '../components/nav'
+import Head from '../components/head'
 
 type Props = {}
 
@@ -115,6 +116,7 @@ class InterviewSchedule extends Component<Props> {
   render() {
     return (
       <div>
+        <Head title="Interview Schedule" />
         <Nav />
         <Container style={{ overflow: 'hidden' }}>
           <h1>Upcoming Interviews</h1>

--- a/frontend/src/pages/rounds.js
+++ b/frontend/src/pages/rounds.js
@@ -8,6 +8,7 @@ import RoundDropdown from '../components/roundDropdown'
 import roundData from '../data/roundData.js'
 import { setRoundRedux } from '../actions'
 import Nav from '../components/nav'
+import Head from '../components/head'
 
 const mapStateToProps = state => ({
   round: state.round,
@@ -56,6 +57,7 @@ class Rounds extends Component {
   render() {
     return (
       <>
+        <Head title="Interview Rounds" />
         <Nav />
         <div className="align-middle round-box">
           <Modal isOpen={this.state.modalOpen} autoFocus={false}>

--- a/frontend/src/pages/stats.js
+++ b/frontend/src/pages/stats.js
@@ -3,6 +3,7 @@ import { Container } from 'reactstrap'
 import { getCandidates } from '../utils/api'
 import { statusEnum, yearsEnum } from '../utils/enums'
 import Nav from '../components/nav'
+import Head from '../components/head'
 
 type Props = {}
 
@@ -32,6 +33,7 @@ class StatsPage extends Component<Props> {
     )
     return (
       <>
+        <Head title="Email & Stats" />
         <Nav />
         <Container>
           <h1>Statistics</h1>

--- a/frontend/src/pages/table.js
+++ b/frontend/src/pages/table.js
@@ -9,6 +9,7 @@ import CandidateLinksBadge from '../components/candidateLinksBadge'
 import { compareByFacemashScore } from '../utils/core'
 import ChangeStatus from '../components/changeStatus'
 import Nav from '../components/nav'
+import Head from '../components/head'
 
 type Props = {}
 
@@ -46,6 +47,7 @@ class TablePage extends React.Component<Props> {
     filteredCandidates.sort(compareByFacemashScore)
     return (
       <>
+        <Head title="Table View" />
         <Nav />
         <Container>
           <Row>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -723,6 +723,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.2.0":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.2.tgz#98f584f4d03be5d8142c77107ffaedee4d5956f1"
+  integrity sha512-9M29wrrP7//JBGX70+IrDuD1w4iOYhUGpJNMQJVNAXue+cFeFlMTqBECouIziXPUphlgrfjcfiEpGX4t0WGK4g==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0.tgz#c2bc9870405959c89a9c814376a2ecb247838c80"
@@ -1954,6 +1961,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
+
 core-js@^2.4.0, core-js@^2.5.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
@@ -2017,6 +2029,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-react-context@<=0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
+  integrity sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
 
 cross-spawn@5.1.0, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -2273,6 +2293,13 @@ encodeurl@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
@@ -2589,6 +2616,19 @@ fast-levenshtein@~2.0.4:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fbjs@^0.8.0:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
 figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -2852,6 +2892,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.4
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -2994,7 +3039,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-iconv-lite@^0.4.17, iconv-lite@^0.4.4:
+iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -3269,6 +3314,11 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
+is-stream@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
 is-symbol@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
@@ -3302,6 +3352,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isomorphic-unfetch@^2.0.0:
   version "2.1.1"
@@ -3896,6 +3954,14 @@ next@^7:
     worker-farm "1.5.2"
     write-file-webpack-plugin "4.3.2"
 
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
 node-fetch@^2.1.2:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
@@ -4323,7 +4389,7 @@ pluralize@^7.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
 
-popper.js@^1.14.1:
+popper.js@^1.14.4:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
   integrity sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==
@@ -4378,7 +4444,7 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-promise@^7.0.1:
+promise@^7.0.1, promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
@@ -4577,13 +4643,17 @@ react-minimal-pie-chart@^3.3.0:
   dependencies:
     prop-types "^15.5.7"
 
-react-popper@^0.10.4:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.10.4.tgz#af2a415ea22291edd504678d7afda8a6ee3295aa"
-  integrity sha1-rypBXqIike3VBGeNev2opu4ylao=
+react-popper@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.3.tgz#2c6cef7515a991256b4f0536cd4bdcb58a7b6af6"
+  integrity sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==
   dependencies:
-    popper.js "^1.14.1"
+    "@babel/runtime" "^7.1.2"
+    create-react-context "<=0.2.2"
+    popper.js "^1.14.4"
     prop-types "^15.6.1"
+    typed-styles "^0.0.7"
+    warning "^4.0.2"
 
 react-redux@^5.0.7:
   version "5.1.1"
@@ -4631,18 +4701,19 @@ react@^16.7.0:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-reactstrap@^6.1.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/reactstrap/-/reactstrap-6.5.0.tgz#ba655e32646e2621829f61faa033e607ec6624e5"
-  integrity sha512-dWb3fB/wBAiQloteKlf+j9Nl2VLe6BMZgTEt6hpeTt0t9TwtkeU+2v2NBYONZaF4FZATfMiIKozhWpc2HmLW1g==
+reactstrap@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/reactstrap/-/reactstrap-8.0.0.tgz#db24d0127e58db89baa743dc660b65f611fe9b84"
+  integrity sha512-Rd7MyaFnZZXe1lbeBlgkxzyv+u7Z/ots0yYoO6ijT7/0uGsNwB1ch2h2t7Tf6u05jpbTFlLD+lyBEER0eibcQw==
   dependencies:
+    "@babel/runtime" "^7.2.0"
     classnames "^2.2.3"
     lodash.isfunction "^3.0.9"
     lodash.isobject "^3.0.2"
     lodash.tonumber "^4.0.3"
     prop-types "^15.5.8"
     react-lifecycles-compat "^3.0.4"
-    react-popper "^0.10.4"
+    react-popper "^1.3.3"
     react-transition-group "^2.3.1"
 
 read-pkg@^2.0.0:
@@ -4993,7 +5064,7 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4:
+setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -5519,10 +5590,20 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+typed-styles@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
+  integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+ua-parser-js@^0.7.18:
+  version "0.7.20"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
+  integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
 
 uglify-es@^3.3.4:
   version "3.3.9"
@@ -5686,6 +5767,13 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
   integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
 
+warning@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
+
 watchpack@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
@@ -5791,6 +5879,11 @@ webpackbar@2.6.3:
     schema-utils "^1.0.0"
     std-env "^1.3.1"
     table "^4.0.3"
+
+whatwg-fetch@>=0.10.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whet.extend@~0.9.9:
   version "0.9.9"


### PR DESCRIPTION
- Posted reminder to write interview notes somewhere else so there's a lower likelihood of interviewers losing their notes. Future improvement would be #118. 
![image](https://user-images.githubusercontent.com/27740557/60863494-bfd4a180-a1d5-11e9-86c7-235d147f08ca.png)
- Fix bug where opening the interview modal would show a blank modal if there weren't any interviews
![image](https://user-images.githubusercontent.com/27740557/60863552-f6aab780-a1d5-11e9-83b5-cfd6e2b001d3.png)
- Custom Headers for each page. Now, candidate pages will have their names as the page title, which shows up in your tab. Whenever you are adding an interview for a candidate named "Sarah", the title will be `Adding Interview for Sarah`
---
![image](https://user-images.githubusercontent.com/27740557/60863598-1c37c100-a1d6-11e9-816b-db10f0587341.png)
---
![image](https://user-images.githubusercontent.com/27740557/60863836-c283c680-a1d6-11e9-8965-b1e3e3bee0bd.png)
