### PR TITLE
Add ability to run with Docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,17 +1,5 @@
-# FROM mhart/alpine-node:10.7.0 as test
-# WORKDIR /usr/src/app
-# COPY . .
-# RUN yarn install
-# RUN yarn test
-
-FROM mhart/alpine-node:10.7.0 as build
+FROM mhart/alpine-node:12.8.0
 WORKDIR /usr/src/app
-COPY package.json .
-COPY yarn.lock .
-RUN yarn install --production
-
-FROM mhart/alpine-node:base-10.7.0
-WORKDIR /usr/src/app
-COPY --from=build /usr/src/app/node_modules node_modules
 COPY . .
-CMD [ "node", "src/index.js" ]
+RUN yarn install
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,9 @@
 FROM mhart/alpine-node:12.8.0
 WORKDIR /usr/src/app
-COPY . .
+# Copy over the module files separately so that they're cached as a build layer
+# (i.e. no rebuild necessary if these don't change) 
+COPY package.json . 
+COPY yarn.lock .
 RUN yarn install
+COPY . .
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,17 @@
-FROM mhart/alpine-node:12.8.0
-WORKDIR /usr/src/app
-# Copy over the module files separately so that they're cached as a build layer
-# (i.e. no rebuild necessary if these don't change) 
-COPY package.json . 
-COPY yarn.lock .
-RUN yarn install
-COPY . .
+# FROM mhart/alpine-node:10.7.0 as test
+# WORKDIR /usr/src/app
+# COPY . .
+# RUN yarn install
+# RUN yarn test
 
+FROM mhart/alpine-node:10.7.0 as build
+WORKDIR /usr/src/app
+COPY package.json .
+COPY yarn.lock .
+RUN yarn install --production
+
+FROM mhart/alpine-node:base-10.7.0
+WORKDIR /usr/src/app
+COPY --from=build /usr/src/app/node_modules node_modules
+COPY . .
+CMD [ "node", "src/index.js" ]

--- a/backend/Dockerfile-dev
+++ b/backend/Dockerfile-dev
@@ -1,0 +1,9 @@
+FROM mhart/alpine-node:12.8.0
+WORKDIR /usr/src/app
+# Copy over the module files separately so that they're cached as a build layer
+# (i.e. no rebuild necessary if these don't change) 
+COPY package.json . 
+COPY yarn.lock .
+RUN yarn install
+COPY . .
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,6 +2,53 @@
 
 ## Setup
 
+In order to have all the secret keys set up properly, you must create a `.env` file and a `keys.json` file to the root of this directory (`./backend`).
+
+Example setup:
+
+In `.env`:
+```
+MONGO_UURL=mongodb://mongouser:mykey@somedb.mlab.com:port/db
+MONGO_DURL=mongodb://mongouser:mykey@somedb.mlab.com:port/db
+MONGO_URL=mongodb://mongouser:mykey@somedb.mlab.com:port/db
+LEAD_SUFFIX=l
+DIRECTOR_SUFFIX=d
+KEY_JSON=../../keys.json
+SCHEDULER_URL=https://scheduler-URI.amazonaws.com/endpoint
+SCHEDULER_API_KEY=abcd1234
+```
+
+In `keys.json`:
+```
+{
+  "keys": [
+    {
+      "name": "Director 1",
+      "key": "1234"
+    }
+  ]
+}
+```
+
+### Docker
+
+To run with [Docker](https://www.docker.com/) (and start the frontend and backend all at once with one command):
+```
+docker-compose up
+```
+
+And when you're done, you can run:
+```
+docker-compose down -v
+```
+
+Note that if there's a change in the `package.json` file (such as a new module added into the repository), instead of running `yarn add` to re-install, just run `docker-compose up --build`. 
+
+
+### Manual
+
+You must install `dotenv-cli`:
+
 ```sh
 yarn global add dotenv-cli
 ```
@@ -17,7 +64,6 @@ Note: `yarn global add` will default to adding packages to `~/.yarn/bin` so by d
 1.  You can add yarn's default installation location to your `$PATH` environment variable, so that your terminal knows where to look for the executables. You can do this by adding `export PATH="$(yarn global bin):$PATH"` as a line in your `~/.bashrc`. Then simply quit your terminal and reopen it (or run source ~/.bashrc) and everything should work.
 2.  Alternatively, you can change the default global location for yarn (`yarn config set prefix <filepath>`) and set `filepath` to something like `/usr/local` or `/usr` (or anything else in your `$PATH` that makes sense). This second method will require you to re-run the above global add command.
 
-Then, you must copy a `.env` file and a `keys.json` file to this folder.
 
 ```sh
 yarn

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -12,8 +12,9 @@ mongoose.connection
   .once('open', () => console.log('Connected to MongoLab instance.'))
   .on('error', error => console.log('Error connecting to MongoLab:', error))
 
+const API_PORT = process.env.PORT === undefined ? 8080 : process.env.PORT
 // start server
-app.listen(8080, async () => console.log('Server listening on port 8080!'))
+app.listen(API_PORT, async () => console.log(`Server listening on port ${API_PORT}!`))
 
 process.on('unhandledRejection', error => {
   // Will print "unhandledRejection err is not defined"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@
 version: "3"
 services:
   backend:
-    build: ./backend
+    build: 
+      context: ./backend
+      dockerfile: Dockerfile-dev
     ports:
       - 8080:8080
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,25 @@ services:
   backend:
     build: ./backend
     ports:
-      - 8080:8080
+      - 3001:3001
     env_file:
       - backend/.env
+    environment:
+      - PORT=3001
     command:
       yarn dev
+    tty: true
 
-  
+  frontend:
+    build: ./frontend
+    ports:
+      - 3000:3000
+    depends_on:
+      - backend
+    environment:
+      - DEBUG_REDUX=false
+      - BACKEND_PORT=3001
+    command:
+      yarn dev
+    tty: true
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+# docker-compose.yml
+version: "3"
+services:
+
+  backend:
+    build: ./backend
+    ports:
+      - 8080:8080
+    env_file:
+      - backend/.env
+    command:
+      yarn dev
+
+  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,22 @@
 # docker-compose.yml
 version: "3"
 services:
-
   backend:
     build: ./backend
     ports:
-      - 3001:3001
+      - 8080:8080
     env_file:
       - backend/.env
     environment:
-      - PORT=3001
-    command:
-      yarn dev
+      - PORT=8080
+    volumes:
+      - ./backend:/usr/src/app
+      # expose a named volume that works because installing
+      # and then mounting will hide that folder, so we need to explicitly
+      # show it again
+      # note that when reinstalling modules, we need to remove this volume
+      - be_modules:/usr/src/app/node_modules
+    command: yarn dev
     tty: true
 
   frontend:
@@ -22,8 +27,17 @@ services:
       - backend
     environment:
       - DEBUG_REDUX=false
-      - BACKEND_PORT=3001
-    command:
-      yarn dev
+      - BACKEND_PORT=8080
+    volumes:
+      - ./frontend:/usr/src/app
+      # expose a named volume that works because installing
+      # and then mounting will hide that folder, so we need to explicitly
+      # show it again
+      # note that when reinstalling modules, we need to remove this volume
+      - fe_modules:/usr/src/app/node_modules
+    command: yarn dev
     tty: true
 
+volumes:
+  fe_modules:
+  be_modules:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM mhart/alpine-node:12.8.0
+WORKDIR /usr/src/app
+COPY package.json . 
+COPY yarn.lock .
+RUN yarn install
+COPY . .

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,10 +8,29 @@ This is built using Next.js, which renders React server side
 
 To start:
 
+### Docker
+
+To run with [Docker](https://www.docker.com/) (and start the frontend and backend all at once with one command):
+```
+docker-compose up
+```
+
+And when you're done, you can run:
+```
+docker-compose down -v
+```
+
+Note that if there's a change in the `package.json` file (such as a new module added into the repository), instead of running `yarn add` to re-install, just run `docker-compose up --build`. 
+
+
+### Manual
+
 ```sh
 yarn
 yarn dev
 ```
+
+
 
 Before every commit, you will need to run prettier or the build will fail.
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -5,5 +5,8 @@ module.exports = {
       fs: 'empty'
     }
     return config
+  },
+  publicRuntimeConfig: {
+    BACKEND_PORT: process.env.BACKEND_PORT === undefined ? 8080 : process.env.BACKEND_PORT
   }
 }

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -6,7 +6,9 @@ import configureStore from '../store/appStore'
 import ErrorMessage from '../components/errorMessage'
 import { PageTransition } from 'next-page-transitions'
 
-export default withRedux(configureStore, { debug: process.env.DEBUG_REDUX === undefined ? false : process.env.DEBUG_REDUX === 'true' })(
+export default withRedux(configureStore, {
+  debug: process.env.DEBUG_REDUX === undefined ? false : process.env.DEBUG_REDUX === 'true'
+})(
   class MyApp extends App {
     constructor(props) {
       super(props)

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -6,7 +6,7 @@ import configureStore from '../store/appStore'
 import ErrorMessage from '../components/errorMessage'
 import { PageTransition } from 'next-page-transitions'
 
-export default withRedux(configureStore, { debug: true })(
+export default withRedux(configureStore, { debug: process.env.DEBUG_REDUX === undefined ? false : process.env.DEBUG_REDUX === 'true' })(
   class MyApp extends App {
     constructor(props) {
       super(props)

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,12 +1,16 @@
 //@flow
 import fetch from 'isomorphic-unfetch'
+import getConfig from 'next/config'
+const { publicRuntimeConfig } = getConfig()
 
 const getKey = () => localStorage.getItem('interviewerKey')
+
+const API_PORT = publicRuntimeConfig.BACKEND_PORT
 
 const API_URL =
   process.env.NODE_ENV === 'production'
     ? 'https://hack4impact-recruitment-backend.now.sh'
-    : 'http://localhost:8080' // make sure your backend is running on this port.
+    : `http://localhost:${API_PORT}` // make sure your backend is running on this port.
 // if your frontend can't connect, try the normal IP
 
 function getAllEvents() {


### PR DESCRIPTION
Resolves #260

This change allows us to run the frontend and backend all at once with no installation needed, just one command: `docker-compose up`! 🎉
Also we have the uniformity and reproducibility of bugs among all our developers using Docker with this change.

This is meant to be run in a dev environment, so we use volumes to allow changes made locally to be reflected in the container. 

This also addresses factoring out environment variables (fix #328)


<img width="932" alt="Screen Shot 2019-08-12 at 3 46 41 AM" src="https://user-images.githubusercontent.com/8664074/62854064-d3cb6180-bcb3-11e9-995e-dc675f9a8f08.png">
