### PR TITLE
Fix Interview Notes Page not rendering + move referral section to right

### DIFF
--- a/frontend/src/components/candidates/candidateBox.js
+++ b/frontend/src/components/candidates/candidateBox.js
@@ -159,7 +159,7 @@ class CandidateBox extends Component {
           <Col md={4}>
             <Row>
               <Col md={12}>
-                <h5 className="text-info pt-3">Additional Information</h5>
+                <h4 className="text-info pt-3">Additional Information</h4>
 
                 {candidate.major && (
                   <p>

--- a/frontend/src/components/candidates/candidateBox.js
+++ b/frontend/src/components/candidates/candidateBox.js
@@ -106,14 +106,6 @@ class CandidateBox extends Component {
               {candidate.classesTaken != undefined ? candidate.classesTaken.join(', ') : null}
             </p>{' '}
             <p>
-              <b>Strong Referrals: </b>
-              {candidate.strongReferrals != undefined ? candidate.strongReferrals.join(', ') : null}
-            </p>
-            <p>
-              <b>Referrals: </b>
-              {candidate.referrals != undefined ? candidate.referrals.join(', ') : null}
-            </p>
-            <p>
               <b>How They know us:</b> {candidate.howTheyKnowUs}
             </p>
             <p>
@@ -205,6 +197,19 @@ class CandidateBox extends Component {
                 </p>
                 <p>
                   <b>Number of Matches: </b> {candidate.facemashRankings.numOfMatches}
+                </p>
+              </Col>
+            </Row>
+            <Row>
+              <Col md={12}>
+                <h4 className="text-info pt-3">Referrals</h4>
+                <p>
+                  <b>Strong Referrals: </b>
+                  {candidate.strongReferrals && candidate.strongReferrals.join(', ')}
+                </p>
+                <p>
+                  <b>Referrals: </b>
+                  {candidate.referrals && candidate.referrals.join(', ')}
                 </p>
               </Col>
             </Row>

--- a/frontend/src/pages/interview.js
+++ b/frontend/src/pages/interview.js
@@ -139,6 +139,18 @@ class Interview extends Component<Props> {
     })
   }
 
+  componentDidUpdate(prevProps) {
+    const { round } = this.props
+    if (prevProps.round !== round) {
+      const currRound = roundData.rounds[round]
+      this.setState({
+        sections: currRound.sections,
+        interviewName: currRound.name,
+        interviewScored: currRound.scored
+      })
+    }
+  }
+
   toggle = () => {
     this.setState({
       verificationModalOpen: !this.state.verificationModalOpen


### PR DESCRIPTION
if you go to `/interview`, it wouldn't render correctly because it requires the current interview "round" (e.g. Mass interview, Facemash, 2nd round etc). 

This "round" is an integer that is retrieved in the navbar by calling the backend. It then is set in the redux state. 

In `/interview` this "round" integer is passed via props from redux but is immediately set in the constructor. Thus, when you reload, the initial value would be `0`. but say "round" is 2. The interview page would not re-render because it doesn't check whether the props changes and correctly updates the interview notes page based on the round.  

The current interview round data in index 0 is for facemash so there aren't any interview note sections, which causes the interview page to not render. 

This diff checks for a new change in props.round and updates the interview notes sections correspondingly. 

I've also moved the Referrals section on the candidate Page to the right.  