### PR TITLE
Fix #287 add fetched list of candidates to redux, dashboard filters, tooltips for referrals

### DIFF
--- a/frontend/src/components/filterComponent.js
+++ b/frontend/src/components/filterComponent.js
@@ -146,7 +146,7 @@ class FilterComponent extends Component<Props> {
               >
                 <option selected>None</option>
                 {this.state.workspaces.map(workspace => (
-                  <option>{workspace.name}</option>
+                  <option key={workspace.name}>{workspace.name}</option>
                 ))}
               </select>
             </p>
@@ -175,7 +175,7 @@ class FilterComponent extends Component<Props> {
           })}
         </>
 
-        <h5>Referrals</h5>
+        <h5 className="mt-2">Referrals</h5>
         <>
           {referrals.map((el, idx) => {
             return (
@@ -197,7 +197,7 @@ class FilterComponent extends Component<Props> {
             )
           })}
         </>
-        <h5>Year</h5>
+        <h5 className="mt-2">Year</h5>
         <>
           {years.map((el, idx) => {
             return (
@@ -219,7 +219,7 @@ class FilterComponent extends Component<Props> {
             )
           })}
         </>
-        <h5>Roles</h5>
+        <h5 className="mt-2">Roles</h5>
         <>
           {roles.map((el, idx) => {
             return (
@@ -241,7 +241,7 @@ class FilterComponent extends Component<Props> {
             )
           })}
         </>
-        <h5>Graduation Date:</h5>
+        <h5 className="mt-2">Graduation Date:</h5>
         <>
           {gradDates.map((el, idx) => {
             return (
@@ -263,7 +263,7 @@ class FilterComponent extends Component<Props> {
             )
           })}
         </>
-        <h4>Sorts</h4>
+        <h4 className="mt-2">Sorts</h4>
         <>
           {sortBy.map((el, idx) => {
             return (

--- a/frontend/src/components/nav.js
+++ b/frontend/src/components/nav.js
@@ -87,20 +87,23 @@ class NavigationBar extends Component {
   }
 
   async componentDidMount() {
-    if (getKey() != undefined) {
-      const { success, result } = await validateKey(getKey())
-      if (success) {
-        this.setState({
-          isLead: result.is_lead,
-          isDirector: result.is_director,
-          loggedIn: true,
-          username: result.name
-        })
-      }
+    if (getKey() === undefined) {
+      return
     }
-    const res = await getRound()
-    if (res.result) {
-      this.props.setRoundRedux(res.result.round)
+    const { success, result } = await validateKey(getKey())
+    if (success) {
+      this.setState({
+        isLead: result.is_lead,
+        isDirector: result.is_director,
+        loggedIn: true,
+        username: result.name
+      })
+    }
+
+    // get interview round data
+    const round = await getRound()
+    if (round.result) {
+      this.props.setRoundRedux(round.result.round)
     } else {
       this.props.setRoundRedux(0)
     }
@@ -117,11 +120,11 @@ class NavigationBar extends Component {
     return (
       <>
         <Navbar style={{ backgroundColor: '#155DA1' }} light className="fixed p-3" expand="sm">
-          <Link prefetch href={this.state.loggedIn ? '/dashboard' : '/'}>
-            <NavbarBrand className="ml-3">
+          <NavbarBrand className="ml-3">
+            <Link href={this.state.loggedIn ? '/dashboard' : '/'}>
               <img id="logo-img" height="35" width="200" src="https://h4i-white-logo.now.sh" />
-            </NavbarBrand>
-          </Link>
+            </Link>
+          </NavbarBrand>
           <NavbarToggler onClick={this.toggle} />
           <Collapse isOpen={this.state.showLoginModal} navbar>
             <Nav navbar className="ml-auto">
@@ -133,31 +136,30 @@ class NavigationBar extends Component {
                 </NavItem>
               )}
               <NavItem>
-                <Link prefetch href="/dashboard">
+                <Link href="/dashboard">
                   <a className="nav-bar-link pl-3">Dashboard</a>
                 </Link>
               </NavItem>
               <NavItem>
-                <Link prefetch href="/table">
+                <Link href="/table">
                   <a className="nav-bar-link pl-3">Table View</a>
                 </Link>
               </NavItem>
               {this.state.isLead && (
                 <>
                   <NavItem>
-                    <Link prefetch href="/eventOverview">
+                    <Link href="/eventOverview">
                       <a className="nav-bar-link pl-3">Events</a>
                     </Link>
                   </NavItem>
 
                   <NavItem>
-                    <Link prefetch href="/interviewportal">
+                    <Link href="/interviewportal">
                       <a className="nav-bar-link pl-3">Your Interviews</a>
                     </Link>
                   </NavItem>
                   <NavItem>
                     <Link
-                      prefetch
                       href={
                         roundData.rounds[this.props.round].type == 'interview'
                           ? '/interviewportal'
@@ -168,34 +170,34 @@ class NavigationBar extends Component {
                     </Link>
                   </NavItem>
                   <NavItem>
-                    <Link prefetch href="/interviewschedule">
+                    <Link href="/interviewschedule">
                       <a className="nav-bar-link pl-3">Interview Schedule</a>
                     </Link>
                   </NavItem>
                   <NavItem>
-                    <Link prefetch href="/stats">
+                    <Link href="/stats">
                       <a className="nav-bar-link pl-3">Emails/Stats</a>
                     </Link>
                   </NavItem>
                   <NavItem>
-                    <Link prefetch href="/analytics">
+                    <Link href="/analytics">
                       <a className="nav-bar-link pl-3">Analytics</a>
                     </Link>
                   </NavItem>
                   {this.state.isDirector && (
                     <>
                       <NavItem>
-                        <Link prefetch href="/workspaces">
+                        <Link href="/workspaces">
                           <a className="nav-bar-link pl-3">Workspaces</a>
                         </Link>
                       </NavItem>
                       <NavItem>
-                        <Link prefetch href="/rounds">
+                        <Link href="/rounds">
                           <a className="nav-bar-link pl-3">Rounds</a>
                         </Link>
                       </NavItem>
                       <NavItem>
-                        <Link prefetch href="/adminRoles">
+                        <Link href="/adminRoles">
                           <a className="nav-bar-link pl-3">Admin</a>
                         </Link>
                       </NavItem>

--- a/frontend/src/pages/interview.js
+++ b/frontend/src/pages/interview.js
@@ -18,7 +18,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import Router from 'next/router'
-import { fetchAllCandidates, addFilter, removeFilter } from '../actions'
+import { fetchAllCandidates, addFilter, removeFilter, fetchCandidatesSuccess } from '../actions'
 import CandidateDropdown from '../components/candidateDropdown'
 import ErrorMessage from '../components/errorMessage'
 import InterviewSectionCard from '../components/interviewSectionCard'
@@ -40,6 +40,7 @@ type Props = {
 const mapDispatchToProps = dispatch => {
   return bindActionCreators(
     {
+      fetchCandidatesSuccess,
       fetchAllCandidates,
       addFilter,
       removeFilter
@@ -64,7 +65,7 @@ class Interview extends Component<Props> {
     super(props)
     this.state = {
       loading: false,
-      candidates: [],
+      candidates: this.props.candidates,
       error: this.props.error,
       filters: this.props.filters,
       sort: this.props.sort,
@@ -133,9 +134,14 @@ class Interview extends Component<Props> {
   }
 
   async componentDidMount() {
-    const res = await getCandidates()
+    if (this.props.candidates.length !== 0) {
+      return
+    }
+    // only fetch for candidates if redux store doesn't hold candidates
+    const { result } = await getCandidates()
+    this.props.fetchCandidatesSuccess(result)
     this.setState({
-      candidates: res.result
+      candidates: result
     })
   }
 
@@ -293,7 +299,7 @@ class Interview extends Component<Props> {
                     </FormFeedback>
                   </InterviewSectionCard>
                   <FormGroup>
-                    <Link prefetch href="/interviewportal">
+                    <Link href="/interviewportal">
                       <Button
                         disabled={this.state.generalNotes === ''}
                         color="primary"


### PR DESCRIPTION
- Resolve #287 - tooltips for people that referred them. They won't show up if there aren't any
- Add fetched List of Candidates to redux
    - `/interviews` will not fetch for candidates, unless redux store is empty. If empty, it will fetch and add to redux store
- Dashboard Filters fixed
    - Filtering by Role: Some people apply to multiple roles. Say someone applied to UI/UX and PM, if I click PM to remove people that applied to be a PM, they should still show up because they still applied for UI/UX. They should only be filtered out if I don't want to see both UI/UX and PM. 
- Search by Candidate ID in the search bar (would be useful later on, especially once we add analytics)
- Some logic is rewritten 
     
![Kapture 2019-08-19 at 20 42 10](https://user-images.githubusercontent.com/27740557/63316159-d8e76c80-c2c2-11e9-9ca9-986ad7e8a29a.gif)
