### PR TITLE
Fix interview rendering due to regression in #302

### DIFF
--- a/frontend/src/components/interviewSectionModular.js
+++ b/frontend/src/components/interviewSectionModular.js
@@ -79,7 +79,7 @@ class InterviewSectionModular extends Component {
         options.push({ name: this.props.textOptions[i], value: this.props.textOptions[i] })
       }
     }
-
+    console.log('notes', this.props.type, this.props.notesPrompt)
     return (
       <InterviewSectionCard title={this.props.title}>
         {this.props.description && (
@@ -107,18 +107,17 @@ class InterviewSectionModular extends Component {
           </>
         )}
 
-        {this.props.notesPrompt ||
-          (this.props.type === 'notes' && (
-            <Input
-              style={{ height: '130px' }}
-              value={this.props.notes}
-              className="textarea-input"
-              onChange={this.handleNotesChange}
-              type="textarea"
-              id="time-commitment-explanation"
-              placeholder={this.props.notesPrompt}
-            />
-          ))}
+        {(this.props.notesPrompt || this.props.type === 'notes') && (
+          <Input
+            style={{ height: '130px' }}
+            value={this.props.notes}
+            className="textarea-input"
+            onChange={this.handleNotesChange}
+            type="textarea"
+            id="time-commitment-explanation"
+            placeholder={this.props.notesPrompt}
+          />
+        )}
       </InterviewSectionCard>
     )
   }

--- a/frontend/src/components/interviewSectionModular.js
+++ b/frontend/src/components/interviewSectionModular.js
@@ -79,7 +79,6 @@ class InterviewSectionModular extends Component {
         options.push({ name: this.props.textOptions[i], value: this.props.textOptions[i] })
       }
     }
-    console.log('notes', this.props.type, this.props.notesPrompt)
     return (
       <InterviewSectionCard title={this.props.title}>
         {this.props.description && (


### PR DESCRIPTION
Interview Inputs were not rendering because of conditional from coding sanitizations (#302). 

Note the placement of the parentheses and how that changes the conditional.