### PR TITLE
Individual interview scores bug skewing averages

### DIFF
--- a/frontend/src/utils/core.js
+++ b/frontend/src/utils/core.js
@@ -25,17 +25,9 @@ const compareByAvgInterviewScore = (candidate1, candidate2) => {
   return 0
 }
 const getNumOfInterviews = interviews => {
-  let total = 0
-  for (var i = 0; i < interviews.length; i++) {
-    if (
-      interviews[i].overall_score !== undefined ||
-      typeof interviews[i].overall_score === 'number'
-    ) {
-      total += 1
-    }
-  }
-  return total
+  return interviews.filter(interview => typeof interview.overall_score === 'number').length
 }
+
 const avgInterviewScore = interviews => {
   if (interviews == undefined || !interviews || interviews.length === 0) {
     return 'N/A'
@@ -44,10 +36,7 @@ const avgInterviewScore = interviews => {
   let avgs = 0
   let good_interviews = interviews.length // to prevent bad interviews from affecting it.
   for (var i = 0; i < interviews.length; i++) {
-    if (
-      interviews[i].overall_score !== undefined ||
-      (typeof interviews[i].overall_score === 'number' && interviews[i].scored)
-    ) {
+    if (typeof interviews[i].overall_score === 'number' && interviews[i].scored) {
       avgs += interviews[i].overall_score
     } else {
       good_interviews -= 1


### PR DESCRIPTION
Resolves #357 

Before (note how there's a score with a 4 and a score with a 3 but the average is 1.750—that's because it's essentially counting individual interviews as a 0 score):
<img width="917" alt="Screen Shot 2019-09-12 at 2 09 35 AM" src="https://user-images.githubusercontent.com/8664074/64761781-80427280-d502-11e9-8c48-b6bbbcec1d79.png">

After:
<img width="960" alt="Screen Shot 2019-09-12 at 2 09 02 AM" src="https://user-images.githubusercontent.com/8664074/64761782-80427280-d502-11e9-8a67-0535e886acec.png">
