### PR TITLE
Replace referrals with contact

### DIFF
--- a/frontend/src/components/candidates/candidateBox.js
+++ b/frontend/src/components/candidates/candidateBox.js
@@ -212,15 +212,8 @@ class CandidateBox extends Component {
             </Row>
             <Row>
               <Col md={12}>
-                <h4 className="text-info pt-3">Referrals</h4>
-                <p>
-                  <b>Strong Referrals: </b>
-                  {candidate.strongReferrals && candidate.strongReferrals.join(', ')}
-                </p>
-                <p>
-                  <b>Referrals: </b>
-                  {candidate.referrals && candidate.referrals.join(', ')}
-                </p>
+                <h4 className="text-info pt-3">Contacts</h4>
+                <p>{candidate.referrals && candidate.referrals.join(', ')}</p>
               </Col>
             </Row>
           </Col>

--- a/frontend/src/components/filterComponent.js
+++ b/frontend/src/components/filterComponent.js
@@ -175,7 +175,7 @@ class FilterComponent extends Component<Props> {
           })}
         </>
 
-        <h5 className="mt-2">Referrals</h5>
+        <h5 className="mt-2">Contacts</h5>
         <>
           {referrals.map((el, idx) => {
             return (

--- a/frontend/src/pages/candidate/[cid].js
+++ b/frontend/src/pages/candidate/[cid].js
@@ -14,7 +14,6 @@ import { ErrorMessage } from '../../components/common'
 import Nav from '../../components/nav'
 import {
   addReferral,
-  addStrongReferral,
   deleteReferral,
   getCandidateById,
   addCommentToCandidate,
@@ -99,13 +98,6 @@ class CandidatePage extends Component {
     this.setState({ candidate: { ...this.state.candidate, referrals: result[1] } })
   }
 
-  // adds strong referral
-  async handleStrongReferral(candidateId) {
-    const { result } = await addStrongReferral(candidateId)
-    this.setState({ candidate: { ...this.state.candidate, strongReferrals: result[0] } })
-    this.setState({ candidate: { ...this.state.candidate, referrals: result[1] } })
-  }
-
   // removes referral
   async handleRemoveReferral(candidateId) {
     const { result } = await deleteReferral(candidateId)
@@ -152,20 +144,14 @@ class CandidatePage extends Component {
               <Button outline color="primary" className="margin-sm-all" onClick={this.toggle}>
                 Add Comment
               </Button>
-              <Button
-                outline
-                color="primary"
-                onClick={() => this.handleStrongReferral(candidate._id)}
-              >
-                Strong Refer
-              </Button>
+
               <Button
                 outline
                 color="primary"
                 className="ml-3"
                 onClick={() => this.handleReferral(candidate._id)}
               >
-                Refer
+                Add contact
               </Button>
               <Button
                 outline
@@ -173,7 +159,7 @@ class CandidatePage extends Component {
                 className="ml-3"
                 onClick={() => this.handleRemoveReferral(candidate._id)}
               >
-                Delete Refer
+                Remove contact
               </Button>
             </Col>
             <Col md={4}>

--- a/frontend/src/pages/dashboard.js
+++ b/frontend/src/pages/dashboard.js
@@ -205,8 +205,7 @@ class Dashboard extends Component {
                             {selects.includes('Major') && <th>Major</th>}
                             {selects.includes('Hours') && <th>Hours</th>}
                             {selects.includes('Links') && <th>Links</th>}
-                            {selects.includes('Strong Referrals') && <th>Strong Referrals</th>}
-                            {selects.includes('Referrals') && <th>Referrals</th>}
+                            {selects.includes('Contacts') && <th>Contacts</th>}
                             {selects.includes('Avg Interview Score') && (
                               <th>Avg Interview Score</th>
                             )}
@@ -273,25 +272,7 @@ class Dashboard extends Component {
                                   </td>
                                 )}
 
-                                {selects.includes('Strong Referrals') && (
-                                  <>
-                                    <td id={`strong${key}`}>
-                                      <span id={`strong-refer-${key}`}>
-                                        {candidate.strongReferrals.length}
-                                      </span>
-                                    </td>
-                                    {candidate.strongReferrals.length > 0 && (
-                                      <UncontrolledTooltip
-                                        placement="right"
-                                        target={`strong-refer-${key}`}
-                                      >
-                                        {candidate.strongReferrals}
-                                      </UncontrolledTooltip>
-                                    )}
-                                  </>
-                                )}
-
-                                {selects.includes('Referrals') && (
+                                {selects.includes('Contacts') && (
                                   <>
                                     <td>
                                       <span id={`refer-${key}`}>{candidate.referrals.length}</span>

--- a/frontend/src/pages/table.js
+++ b/frontend/src/pages/table.js
@@ -61,8 +61,7 @@ class TablePage extends Component {
                   <th>Status</th>
                   <th>Graduation Date</th>
                   <th>Links</th>
-                  <th>Strong Referrals</th>
-                  <th>Referrals</th>
+                  <th>Contacts</th>
                   <th>FaceMash Score</th>
                   <th>Matches</th>
                   <th>Change Status</th>
@@ -88,7 +87,6 @@ class TablePage extends Component {
                         <CandidateLinksBadge link={candidate.github} text="Github" />
                         <CandidateLinksBadge link={candidate.website} text="Website" />
                       </td>
-                      <td>{candidate.strongReferrals.length}</td>
                       <td>{candidate.referrals.length}</td>
                       <td>
                         {candidate.facemashRankings != undefined


### PR DESCRIPTION
Removes instances of the word "referral" on the frontend (entirely removing strong referrals from the interface), replacing them with "contact" to indicate that the applicant is known by the corresponding member (adding an applicant as a "contact" does not indicate that they are to receive preferential consideration, but instead is just for bookkeeping and transparency in deliberation).